### PR TITLE
Fix radar chart loading by using Chart.js UMD build

### DIFF
--- a/src/bitescore/app/chatbot.py
+++ b/src/bitescore/app/chatbot.py
@@ -748,11 +748,14 @@ def _build_sequence_card(
       return;
     }}
     if (!window.bitescoreChartJsPromise) {{
-      window.bitescoreChartJsPromise = new Promise(function(resolve) {{
+      window.bitescoreChartJsPromise = new Promise(function(resolve, reject) {{
         const script = document.createElement('script');
-        script.src = 'https://cdn.jsdelivr.net/npm/chart.js';
+        script.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js';
         script.onload = function() {{ resolve(); }};
+        script.onerror = function(err) {{ reject(err); }};
         document.head.appendChild(script);
+      }}).catch(function(err) {{
+        console.error('Failed to load Chart.js', err);
       }});
     }}
     window.bitescoreChartJsPromise.then(renderChart);


### PR DESCRIPTION
## Summary
- load the Chart.js UMD bundle so the global Chart constructor is defined
- add an error handler when loading Chart.js to aid debugging if the CDN fails

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d11cfd12dc8326b2fb2c62d89abcef